### PR TITLE
ENHANCEMENT: Making Exclude Children 3.1 ready

### DIFF
--- a/code/ExcludeChildren.php
+++ b/code/ExcludeChildren.php
@@ -39,13 +39,13 @@ class ExcludeChildren extends Hierarchy{
 	
 	public function stageChildren($showAll = false) {
 		$staged = parent::stageChildren($showAll);
-		$staged->exclude('ClassName', $this->getExcludedClasses());
+		$staged = $staged->exclude('ClassName', $this->getExcludedClasses());
 		return $staged;
 	}
 	
 	public function liveChildren($showAll = false, $onlyDeletedFromStage = false) {
 		$staged = parent::liveChildren($showAll, $onlyDeletedFromStage);
-		$staged->exclude('ClassName', $this->getExcludedClasses());
+		$staged = $staged->exclude('ClassName', $this->getExcludedClasses());
 		return $staged;
 	}
 	


### PR DESCRIPTION
In 3.1 you can not longer write $dataSet->filter(); $dataSet->exclude/filter/whatever

As the original dataset is not longer changed and instead methods like filter return a clone of the original dataset with the new filter/exclude/whatever added.
