### PR TITLE
ENHANCEMENT: Only hide children from SiteTree in CMSMain

### DIFF
--- a/code/ExcludeChildren.php
+++ b/code/ExcludeChildren.php
@@ -39,13 +39,19 @@ class ExcludeChildren extends Hierarchy{
 	
 	public function stageChildren($showAll = false) {
 		$staged = parent::stageChildren($showAll);
-		$staged = $staged->exclude('ClassName', $this->getExcludedClasses());
+		$action = Controller::curr()->getAction();
+		if(in_array($action, array('treeview','getsubtree'))) {
+			$staged = $staged->exclude('ClassName', $this->getExcludedClasses());
+		}
 		return $staged;
 	}
 	
 	public function liveChildren($showAll = false, $onlyDeletedFromStage = false) {
 		$staged = parent::liveChildren($showAll, $onlyDeletedFromStage);
-		$staged = $staged->exclude('ClassName', $this->getExcludedClasses());
+		$action = Controller::curr()->getAction();
+		if(in_array($action, array('treeview','getsubtree'))) {
+			$staged = $staged->exclude('ClassName', $this->getExcludedClasses());
+		}
 		return $staged;
 	}
 	


### PR DESCRIPTION
Applying a universal exclusion filter has the unintended consequence of filtering out TreeDropdownFields (e.g. in the EditToolbar link form in HtmlEditorField), meaning these pages are invisible and impossible to link to. This is a bit of an ugly fix, but it seems like the exclusion of the children should be on a white list of controllers rather than a global mutation.
